### PR TITLE
Add testing class namespace on autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
             "hanneskod\\clean\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "hanneskod\\clean\\": "tests/"
+        }
+    },
     "require": {
         "php": ">=7.4"
     },


### PR DESCRIPTION
# Changed log

- Adding the `hanneskod\\clean\\` for testing class namespace on `autoload-dev` setting.